### PR TITLE
OsStrings 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,4 @@
+# Passman, the Tool-Agnostic; Local-First password manager
+
+## Running:
+For development, run it with cargo using `cargo run ARGS`, you may need to give permissions to the project folder, the simplest way is by doing `chmod +x .` while on the correct directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod file_encryption;
 mod passman_encryption;
 use error::PassmanError;
 use rand::{Rng, rng};
+use std::ffi::OsString;
 use std::io::{self, Write};
 use std::{env, fs};
 
@@ -61,7 +62,7 @@ fn create_new_password(service_name: String) -> Result<(), PassmanError> {
     };
 
     file_encryption::create_encrypted_file(
-        &filename,
+        &OsString::from(&filename),
         &master_pwd,
         &service_name,
         random_pass.as_bytes(),
@@ -80,13 +81,11 @@ fn get_password(service_name: String) -> Result<(), PassmanError> {
         service_name
     };
 
-    let password_files = fs::read_dir(file_encryption::OUTPUT_PATH).unwrap();
+    let password_files = fs::read_dir(file_encryption::get_output_path()).unwrap();
 
     for file in password_files {
-        let (file_service_name, service_password) = file_encryption::read_encrypted_file(
-            &file?.file_name().to_string_lossy(),
-            &master_pwd,
-        )?;
+        let (file_service_name, service_password) =
+            file_encryption::read_encrypted_file(&OsString::from(file?.file_name()), &master_pwd)?;
         if file_service_name == service_name {
             println!("{}: {}", service_name, service_password);
             return Ok(());
@@ -123,7 +122,7 @@ fn register_password(service_name: String, service_pwd: String) -> Result<(), Pa
     };
 
     file_encryption::create_encrypted_file(
-        &filename,
+        &OsString::from(&filename),
         &master_pwd,
         &service_name,
         service_pwd.as_bytes(),
@@ -135,7 +134,7 @@ fn register_password(service_name: String, service_pwd: String) -> Result<(), Pa
 }
 
 fn list_files() -> Result<(), PassmanError> {
-    let password_files = fs::read_dir(file_encryption::OUTPUT_PATH).unwrap();
+    let password_files = fs::read_dir(file_encryption::get_output_path()).unwrap();
 
     for file in password_files {
         println!("{}", file.unwrap().path().display())
@@ -147,15 +146,13 @@ fn list_files() -> Result<(), PassmanError> {
 fn list_service_names() -> Result<(), PassmanError> {
     let master_pwd = read_input("Enter master password", true);
 
-    let password_files = fs::read_dir(file_encryption::OUTPUT_PATH).unwrap();
+    let password_files = fs::read_dir(file_encryption::get_output_path()).unwrap();
 
     let mut service_names: Vec<(String, String)> = Vec::new();
 
     for file in password_files {
-        let (file_service_name, service_password) = file_encryption::read_encrypted_file(
-            &file?.file_name().to_string_lossy(),
-            &master_pwd,
-        )?;
+        let (file_service_name, service_password) =
+            file_encryption::read_encrypted_file(&OsString::from(file?.file_name()), &master_pwd)?;
         service_names.push((file_service_name, service_password));
     }
 
@@ -181,7 +178,7 @@ fn decrypt_file_prompt(filename: String) -> Result<(), PassmanError> {
     };
 
     let (service_name, service_password) =
-        file_encryption::read_encrypted_file(&filename, &master_pwd)?;
+        file_encryption::read_encrypted_file(&OsString::from(filename), &master_pwd)?;
 
     println!("{}: {}", service_name, service_password);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,6 @@ fn create_new_password(service_name: String) -> Result<(), PassmanError> {
 
     Ok(())
 }
-
 fn get_password(service_name: String) -> Result<(), PassmanError> {
     let master_pwd = read_input("Enter master password", false);
 
@@ -85,8 +84,7 @@ fn get_password(service_name: String) -> Result<(), PassmanError> {
 
     for file in password_files {
         let (file_service_name, service_password) = file_encryption::read_encrypted_file(
-            //FIXME: remove unwrap spam
-            &file.unwrap().path().file_name().unwrap().to_str().unwrap(),
+            &file?.file_name().to_string_lossy(),
             &master_pwd,
         )?;
         if file_service_name == service_name {
@@ -155,8 +153,7 @@ fn list_service_names() -> Result<(), PassmanError> {
 
     for file in password_files {
         let (file_service_name, service_password) = file_encryption::read_encrypted_file(
-            //FIXME: remove unwrap spam
-            &file.unwrap().path().file_name().unwrap().to_str().unwrap(),
+            &file?.file_name().to_string_lossy(),
             &master_pwd,
         )?;
         service_names.push((file_service_name, service_password));


### PR DESCRIPTION
Using OsStrings, paths now don't need to use unwraps. Also adds support for non utf8 filenames.

Closes #4 Closes #3 Closes #1 